### PR TITLE
Add aliases to .bashrc instead of .bash_profile.

### DIFF
--- a/p
+++ b/p
@@ -2,6 +2,7 @@ curl -L https://raw.githubusercontent.com/twial/scripts/master/run > ~/.run
 chmod u+x ~/.run
 echo "alias p='curl -L https://raw.githubusercontent.com/twial/scripts/master/p | sh'" > ~/.bashrc
 echo "alias r='~/.run'" >> ~/.bashrc
+echo "/bin/bash" >> ~/.bash_profile
 
 # check if the pacman database exists
 pacdb=/var/lib/pacman/db.lck

--- a/p
+++ b/p
@@ -2,7 +2,7 @@ curl -L https://raw.githubusercontent.com/twial/scripts/master/run > ~/.run
 chmod u+x ~/.run
 echo "alias p='curl -L https://raw.githubusercontent.com/twial/scripts/master/p | sh'" > ~/.bashrc
 echo "alias r='~/.run'" >> ~/.bashrc
-echo "/bin/bash" >> ~/.bash_profile
+echo "/bin/bash" > ~/.bash_profile
 
 # check if the pacman database exists
 pacdb=/var/lib/pacman/db.lck

--- a/p
+++ b/p
@@ -1,7 +1,7 @@
 curl -L https://raw.githubusercontent.com/twial/scripts/master/run > ~/.run
 chmod u+x ~/.run
-echo "alias p='curl -L https://raw.githubusercontent.com/twial/scripts/master/p | sh'" > ~/.bash_profile
-echo "alias r='~/.run'" >> ~/.bash_profile
+echo "alias p='curl -L https://raw.githubusercontent.com/twial/scripts/master/p | sh'" > ~/.bashrc
+echo "alias r='~/.run'" >> ~/.bashrc
 
 # check if the pacman database exists
 pacdb=/var/lib/pacman/db.lck


### PR DESCRIPTION
.bash_profile only runs at login shells, while .bashrc runs at every
shell session
